### PR TITLE
Allow null to be passed to focusElement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,9 @@
   },
   "editor.formatOnSave": false,
   "editor.tabSize": 2,
+  "editor.unicodeHighlight.allowedCharacters": {
+    "’": true
+  },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,

--- a/api-extractor/js-dom-utils.api.json
+++ b/api-extractor/js-dom-utils.api.json
@@ -215,7 +215,7 @@
             },
             {
               "kind": "Content",
-              "text": ", options?: "
+              "text": " | null, options?: "
             },
             {
               "kind": "Reference",

--- a/api-extractor/js-dom-utils.api.md
+++ b/api-extractor/js-dom-utils.api.md
@@ -11,6 +11,6 @@ export const announce: ({ priority, text, }: {
 }) => void;
 
 // @public
-export const focusElement: (element: HTMLElement, options?: FocusOptions) => void;
+export const focusElement: (element: HTMLElement | null, options?: FocusOptions) => void;
 
 ```

--- a/docs/js-dom-utils.focuselement.md
+++ b/docs/js-dom-utils.focuselement.md
@@ -9,7 +9,7 @@ Focus a DOM element.
 **Signature:**
 
 ```typescript
-focusElement: (element: HTMLElement, options?: FocusOptions) => void
+focusElement: (element: HTMLElement | null, options?: FocusOptions) => void
 ```
 
 ## Remarks

--- a/src/focusElement.ts
+++ b/src/focusElement.ts
@@ -13,9 +13,14 @@ const onElementBlur = (event: FocusEvent) => {
  * @public
  */
 const focusElement = (
-  element: HTMLElement,
+  element: HTMLElement | null,
   options: FocusOptions = { preventScroll: false },
 ) => {
+  if (!(element instanceof HTMLElement)) {
+    console.error("Couldn’t focus element:", element);
+    return;
+  }
+
   element.setAttribute("tabindex", "-1");
   element.addEventListener("blur", onElementBlur);
   element.focus(options);

--- a/types/js-dom-utils.d.ts
+++ b/types/js-dom-utils.d.ts
@@ -33,6 +33,6 @@ export declare const announce: ({ priority, text, }: {
  *
  * @public
  */
-export declare const focusElement: (element: HTMLElement, options?: FocusOptions) => void;
+export declare const focusElement: (element: HTMLElement | null, options?: FocusOptions) => void;
 
 export { }


### PR DESCRIPTION
Moving this logic into focusElement allows us to remove some redundant project code.

Closes #13